### PR TITLE
feat: refactor showoutofstockprice module and remove deprecated inven…

### DIFF
--- a/ConfigurableProduct/Helper/Data/Data.php
+++ b/ConfigurableProduct/Helper/Data/Data.php
@@ -2,35 +2,56 @@
 
 namespace Nordcomputer\Showoutofstockprice\ConfigurableProduct\Helper\Data;
 
-class Data extends \Magento\ConfigurableProduct\Helper\Data
-{
+use Magento\Catalog\Model\Product;
+use Magento\ConfigurableProduct\Helper\Data as ConfigurableHelperData;
 
+/**
+ * Helper for configurable product option matrix.
+ */
+class Data extends ConfigurableHelperData
+{
+    /**
+     * Build configurable option index for the given allowed child products.
+     *
+     * @param Product $currentProduct
+     * @param Product[] $allowedProducts
+     *
+     * @return array
+     */
     public function getOptions($currentProduct, $allowedProducts)
     {
-        $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
-        $stockRegistry = $objectManager->get(\Magento\CatalogInventory\Api\StockRegistryInterface::class);
-
         $options = [];
         $allowAttributes = $this->getAllowAttributes($currentProduct);
 
         foreach ($allowedProducts as $product) {
-            $productId = $product->getId();
+            if (!$product instanceof Product) {
+                continue;
+            }
 
-            $product = $objectManager->get(\Magento\Catalog\Model\Product::class)->load($productId);
-            $stockitem = $stockRegistry->getStockItem($product->getId(), $product->getStore()->getWebsiteId());
-            if ($stockitem->getQty() == 0) {
+            $productId = (int) $product->getId();
+            if ($productId <= 0) {
                 continue;
             }
 
             foreach ($allowAttributes as $attribute) {
                 $productAttribute = $attribute->getProductAttribute();
-                $productAttributeId = $productAttribute->getId();
-                $attributeValue = $product->getData($productAttribute->getAttributeCode());
+                if ($productAttribute === null) {
+                    continue;
+                }
+
+                $productAttributeId = (int) $productAttribute->getId();
+                $attributeCode = (string) $productAttribute->getAttributeCode();
+                $attributeValue = $product->getData($attributeCode);
+
+                if ($productAttributeId <= 0 || $attributeValue === null || $attributeValue === '') {
+                    continue;
+                }
 
                 $options[$productAttributeId][$attributeValue][] = $productId;
                 $options['index'][$productId][$productAttributeId] = $attributeValue;
             }
         }
+
         return $options;
     }
 }

--- a/Model/ConfigurableProduct/ResourceModel/Product/StockStatusBaseSelectProcessorN.php
+++ b/Model/ConfigurableProduct/ResourceModel/Product/StockStatusBaseSelectProcessorN.php
@@ -6,6 +6,13 @@ use Magento\ConfigurableProduct\Model\ResourceModel\Product\StockStatusBaseSelec
 
 class StockStatusBaseSelectProcessorN extends StockStatusBaseSelectProcessor
 {
+    /**
+     * Methode process
+     *
+     * @param  Select $select
+     *
+     * @return void
+     */
     public function process(Select $select)
     {
         return $select;

--- a/Model/ResourceModel/Product/CompositeBaseSelectProcessor.php
+++ b/Model/ResourceModel/Product/CompositeBaseSelectProcessor.php
@@ -5,12 +5,14 @@ use Magento\CatalogInventory\Model\ResourceModel\Product\StockStatusBaseSelectPr
 
 class CompositeBaseSelectProcessor extends \Magento\Catalog\Model\ResourceModel\Product\CompositeBaseSelectProcessor
 {
+    /**
+     * REMOVE THE STOCK STATUS PROCESSOR
+     *
+     * @param  array $baseSelectProcessors
+     */
     public function __construct(
         array $baseSelectProcessors
     ) {
-
-        // REMOVE THE STOCK STATUS PROCESSOR
-        //...................................
         $finalProcessors = [];
         foreach ($baseSelectProcessors as $baseSelectProcessor) {
             if (!is_a($baseSelectProcessor, StockStatusBaseSelectProcessor::class)) {

--- a/Plugin/InStockOptionSelectorPlugin.php
+++ b/Plugin/InStockOptionSelectorPlugin.php
@@ -2,45 +2,87 @@
 
 namespace Nordcomputer\Showoutofstockprice\Plugin;
 
-use Magento\CatalogInventory\Api\StockConfigurationInterface;
-use Magento\CatalogInventory\Model\ResourceModel\Stock\Status;
 use Magento\ConfigurableProduct\Model\ResourceModel\Attribute\OptionSelectBuilderInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\DB\Select;
-use \Magento\ConfigurableProduct\Plugin\Model\ResourceModel\Attribute\InStockOptionSelectBuilder;
+use Magento\Store\Model\ScopeInterface;
 
-class InStockOptionSelectorPlugin extends InStockOptionSelectBuilder
+/**
+ * Plugin to keep configurable options visible when out-of-stock products
+ * should be displayed on the storefront.
+ */
+class InStockOptionSelectorPlugin
 {
+    /** @var string */
+    private const XML_PATH_SHOW_OUT_OF_STOCK = 'cataloginventory/options/show_out_of_stock';
+
+    /** @var ScopeConfigInterface */
+    private $scopeConfig;
+
     /**
-     * @var StockConfigurationInterface
-     */
-    private $stockConfiguration;
-    /**
-     * InStockOptionSelectBuilder constructor
+     * InStockOptionSelectorPlugin constructor.
      *
-     * @param Status $stockStatusResource
-     * @param StockConfigurationInterface $stockConfiguration
+     * @param ScopeConfigInterface $scopeConfig
      */
     public function __construct(
-        Status $stockStatusResource,
-        StockConfigurationInterface $stockConfiguration
+        ScopeConfigInterface $scopeConfig
     ) {
-        parent::__construct($stockStatusResource, $stockConfiguration);
-        $this->stockConfiguration = $stockConfiguration;
+        $this->scopeConfig = $scopeConfig;
     }
+
     /**
-     * Only Add In stock Filter if Show Out Of Stock Products is set to No
+     * Remove the MSI salability filter
+     *
+     * Remove the MSI salability filter from the configurable option select
+     * when out-of-stock products should be shown.
      *
      * @param OptionSelectBuilderInterface $subject
      * @param Select $select
+     *
      * @return Select
      */
     public function afterGetSelect(
         OptionSelectBuilderInterface $subject,
         Select $select
-    ) {
-        if ($this->stockConfiguration->isShowOutOfStock()) {
-            return parent::afterGetSelect($subject, $select);
+    ): Select {
+        if (!$this->isShowOutOfStockEnabled()) {
+            return $select;
         }
+
+        $whereParts = $select->getPart(Select::WHERE);
+        if (empty($whereParts)) {
+            return $select;
+        }
+
+        $filteredWhereParts = [];
+
+        foreach ($whereParts as $wherePart) {
+            $normalizedWherePart = strtolower((string) $wherePart);
+
+            if (strpos($normalizedWherePart, 'stock.is_salable') !== false
+                && strpos($normalizedWherePart, '= 1') !== false
+            ) {
+                continue;
+            }
+
+            $filteredWhereParts[] = $wherePart;
+        }
+
+        $select->setPart(Select::WHERE, $filteredWhereParts);
+
         return $select;
+    }
+
+    /**
+     * Check whether out-of-stock products should be shown.
+     *
+     * @return bool
+     */
+    private function isShowOutOfStockEnabled(): bool
+    {
+        return $this->scopeConfig->isSetFlag(
+            self::XML_PATH_SHOW_OUT_OF_STOCK,
+            ScopeInterface::SCOPE_STORE
+        );
     }
 }

--- a/Plugin/ShowOutOfStockProductsPlugin.php
+++ b/Plugin/ShowOutOfStockProductsPlugin.php
@@ -1,39 +1,70 @@
 <?php
-
 namespace Nordcomputer\Showoutofstockprice\Plugin;
 
+use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\Product\Attribute\Source\Status;
+use Magento\ConfigurableProduct\Block\Product\View\Type\Configurable;
+use Magento\ConfigurableProduct\Model\Product\Type\Configurable as ConfigurableType;
+
+/**
+ * Plugin to expose configurable child products even when they are out of stock.
+ */
 class ShowOutOfStockProductsPlugin
 {
-
     /**
-     * Get Allowed Products
+     * Return allowed child products for configurable product view.
      *
-     * @return \Magento\Catalog\Model\Product[]
+     * Uses the original result if available and filters only disabled products.
+     * Falls back to all used products when Magento returns an empty array.
+     *
+     * @param Configurable $subject
+     * @param callable $proceed
+     *
+     * @return Product[]
      */
-    public function beforeGetAllowProducts(\Magento\ConfigurableProduct\Block\Product\View\Type\Configurable $subject)
+    public function aroundGetAllowProducts(Configurable $subject, callable $proceed): array
     {
-        if (!$subject->hasAllowProducts()) {
-            $allProducts = $subject->getProduct()->getTypeInstance()->getUsedProducts($subject->getProduct(), null);
-            $products = [];
-            foreach ($allProducts as $product) {
-                if ($product->getStatus() != \Magento\Catalog\Model\Product\Attribute\Source\Status::STATUS_DISABLED) {
-                    $products[] = $product;
-                }
-            }
-            $subject->setAllowProducts($products);
-        } else {
-            $_children = $subject->getProduct()->getExtensionAttributes()->getConfigurableProductLinks();
-            if ($_children!=null) {
-                foreach ($_children as $child) {
-                    $objectManager = \Magento\Framework\App\ObjectManager::getInstance();
-                    $product = $objectManager->create(\Magento\Catalog\Model\Product::class)->load($child);
-                    $products[] = $product;
-                }
-                $subject->setAllowProducts($products);
-            }
+        $products = $proceed();
 
+        if (!empty($products)) {
+            return $this->filterEnabledProducts($products);
         }
 
-        return [];
+        $product = $subject->getProduct();
+        $typeInstance = $product->getTypeInstance();
+
+        if (!$typeInstance instanceof ConfigurableType) {
+            return [];
+        }
+
+        $usedProducts = $typeInstance->getUsedProducts($product, null);
+
+        return $this->filterEnabledProducts($usedProducts);
+    }
+
+    /**
+     * Filter disabled child products from the given product array.
+     *
+     * @param array $products
+     *
+     * @return Product[]
+     */
+    private function filterEnabledProducts(array $products): array
+    {
+        $filteredProducts = [];
+
+        foreach ($products as $product) {
+            if (!$product instanceof Product) {
+                continue;
+            }
+
+            if ((int) $product->getStatus() === Status::STATUS_DISABLED) {
+                continue;
+            }
+
+            $filteredProducts[] = $product;
+        }
+
+        return $filteredProducts;
     }
 }

--- a/Plugin/ShowPrice.php
+++ b/Plugin/ShowPrice.php
@@ -1,15 +1,30 @@
 <?php
 namespace Nordcomputer\Showoutofstockprice\Plugin;
 
+use Magento\Catalog\Model\Product;
+use Magento\ConfigurableProduct\Pricing\Price\ConfigurablePriceResolver;
+
+/**
+ * Plugin to provide a fallback price for configurable products.
+ */
 class ShowPrice
 {
+    /**
+     * Set fallback price if configurable price resolver returns an empty value.
+     *
+     * @param ConfigurablePriceResolver $subject
+     * @param float|int|string|null $price
+     * @param Product $product
+     *
+     * @return float
+     */
     public function afterResolvePrice(
-        \Magento\ConfigurableProduct\Pricing\Price\ConfigurablePriceResolver $subject,
+        ConfigurablePriceResolver $subject,
         $price,
-        $product
-    ) {
-        $price = $price ?: $product->getData('price');
+        Product $product
+    ): float {
+        $resolvedPrice = $price !== null ? (float) $price : (float) $product->getData('price');
 
-        return $price;
+        return $resolvedPrice;
     }
 }

--- a/Pricing/Render/FinalPriceBox.php
+++ b/Pricing/Render/FinalPriceBox.php
@@ -1,14 +1,24 @@
 <?php
 namespace Nordcomputer\Showoutofstockprice\Pricing\Render;
 
+use Magento\ConfigurableProduct\Pricing\Render\FinalPriceBox as ConfigurableFinalPriceBox;
 use Magento\Framework\Pricing\Render\PriceBox as BasePriceBox;
+use Magento\Msrp\Pricing\Price\MsrpPrice;
 
-class FinalPriceBox extends \Magento\ConfigurableProduct\Pricing\Render\FinalPriceBox
+/**
+ * Custom final price box renderer for configurable products.
+ */
+class FinalPriceBox extends ConfigurableFinalPriceBox
 {
-    protected function _toHtml()
+    /**
+     * Render final price HTML.
+     *
+     * @return string
+     */
+    protected function _toHtml(): string
     {
         $result = BasePriceBox::_toHtml();
-        //Renders MSRP in case it is enabled
+
         if ($this->isMsrpPriceApplicable()) {
             /** @var BasePriceBox $msrpBlock */
             $msrpBlock = $this->rendererPool->createPriceRender(
@@ -19,6 +29,7 @@ class FinalPriceBox extends \Magento\ConfigurableProduct\Pricing\Render\FinalPri
                     'zone' => $this->getZone(),
                 ]
             );
+
             $result = $msrpBlock->toHtml();
         }
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "nordcomputer/showoutofstockprice",
     "description": "Adds price to out-of-stock products and shows Swatches for configurable out-of-stock products",
-    "version": "v0.6",
+    "version": "v0.7",
     "type": "magento2-module",
     "license": [
         "OSL-3.0",


### PR DESCRIPTION
…tory usage

- replaced expensive before-plugin on getAllowProducts with a lean around-plugin
- removed ObjectManager usage and product load() calls inside loops
- simplified configurable option building to use already loaded allowed products
- removed deprecated CatalogInventory dependencies from option selector plugin
- replaced legacy stock-based filtering with scope-config based out-of-stock handling
- fixed configurable option select behavior for out-of-stock child products
- added proper type hints, docblocks and cleaned up renderer/plugin classes
- reduced performance overhead of configurable product rendering significantly